### PR TITLE
✨Add guild count and names command.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ DISCORD_BOT_NAME=<string: The music bot's name>
 PREFIX=<string: Bot's prefix>
 PREFIX_2=<string: Bot's prefix>
 KZILLA_CUSTOM_EMOJI=<string: SRMKZILLA's server's custom emoji for the bot>
+KZILLA_BOT_ADMIN_ID=<string: SRMKZILLA's bot admin's custom role ID>

--- a/src/commands/guildCount.ts
+++ b/src/commands/guildCount.ts
@@ -1,0 +1,19 @@
+import { Message } from 'discord.js';
+import { kzillaBotAdminCheck } from '../shared/auth';
+import { EMBED, MESSAGES } from '../shared/constants';
+
+export const guildCountHandler = async (message: Message): Promise<void> => {
+  if (await kzillaBotAdminCheck(message)) {
+    let counter = 0,
+      listOfGuilds = 'Index\u3000\u3000\u3000Guild Name\n';
+    message.client.guilds.cache.each(value => {
+      listOfGuilds += `${++counter}\u3000\u3000\u3000\u3000\u3000${value.name}\n`;
+    });
+    while (listOfGuilds.length > 0) {
+      message.channel.send(EMBED().setTitle(MESSAGES.GUILD_COUNT_MESSAGE).setDescription(listOfGuilds));
+      listOfGuilds.length > 2000
+        ? (listOfGuilds = listOfGuilds.substring(2000, listOfGuilds.length))
+        : (listOfGuilds = '');
+    }
+  }
+};

--- a/src/commands/guildCount.ts
+++ b/src/commands/guildCount.ts
@@ -1,11 +1,17 @@
 import { Message } from 'discord.js';
+import config from '../config';
 import { kzillaBotAdminCheck } from '../shared/auth';
 import { EMBED, MESSAGES } from '../shared/constants';
+
+/**
+ * Fetches and sends the list of guilds the bot is in.
+ * @param {Message} message The incoming message
+ */
 
 export const guildCountHandler = async (message: Message): Promise<void> => {
   if (await kzillaBotAdminCheck(message)) {
     let counter = 0,
-      listOfGuilds = 'Index\u3000\u3000\u3000Guild Name\n';
+      listOfGuilds = `${config.DISCORD_BOT_NAME} is in **${message.client.guilds.cache.size} guilds**! 🎉🥳\n\n**Index**\u3000\u3000\u3000**Guild Name**\n`;
     message.client.guilds.cache.each(value => {
       listOfGuilds += `${++counter}\u3000\u3000\u3000\u3000\u3000${value.name}\n`;
     });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -13,3 +13,4 @@ export { lyricsCommandHandler } from './lyrics';
 export { lyricsFindCommandHandler } from './lyricsFind';
 export { clearCommandHandler } from './clear';
 export { skiptoCommandHandler } from './skipto';
+export { guildCountHandler } from './guildCount';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,6 +3,7 @@ require('dotenv').config();
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 export default {
+  KZILLA_BOT_ADMIN_ID: process.env.KZILLA_BOT_ADMIN_ID,
   /**
    * SRMKZILLA's custom emoji for the music bot
    */

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,6 +3,9 @@ require('dotenv').config();
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 export default {
+  /**
+   * The id of the "SRMKZILLA bot admin" role
+   */
   KZILLA_BOT_ADMIN_ID: process.env.KZILLA_BOT_ADMIN_ID,
   /**
    * SRMKZILLA's custom emoji for the music bot

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   shuffleCommandHandler,
   skipCommandHandler,
   skiptoCommandHandler,
+  guildCountHandler,
 } from './commands';
 import config from './config';
 import { connectionMap } from './controller';
@@ -83,6 +84,9 @@ const discordHandler = async () => {
             break;
           case COMMANDS.STOP:
             leaveCommandHandler(message, MESSAGES.STOP_MUSIC);
+            break;
+          case COMMANDS.KZADMIN_GUILD_COUNT:
+            await guildCountHandler(message);
             break;
           default:
             defaultCaseHandler(message);

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -1,4 +1,5 @@
 import { Message } from 'discord.js';
+import config from '../config';
 import { ERROR_MESSAGES } from './constants';
 
 /**
@@ -7,7 +8,7 @@ import { ERROR_MESSAGES } from './constants';
  * @returns {boolean} Returns a boolean value
  */
 
-export const userInVoiceChannelCheck = (message:Message) : boolean=> {
+export const userInVoiceChannelCheck = (message: Message): boolean => {
   if (!message.member.voice.channel) {
     message.reply(ERROR_MESSAGES.USER_NOT_IN_A_VOICE_CHANNEL);
     return false;
@@ -23,4 +24,10 @@ export const userInVoiceChannelCheck = (message:Message) : boolean=> {
     }
   }
   return true;
+};
+
+export const kzillaBotAdminCheck = async (message: Message) => {
+  if (message.member.roles.cache.find(role => role.id === config.KZILLA_BOT_ADMIN_ID)) return true;
+  message.reply(ERROR_MESSAGES.USER_NOT_ADMIN);
+  return false;
 };

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -26,7 +26,13 @@ export const userInVoiceChannelCheck = (message: Message): boolean => {
   return true;
 };
 
-export const kzillaBotAdminCheck = async (message: Message) => {
+/**
+ * Check if the user has the necesarry roles or not.
+ * @param {Message} message The incoming message
+ * @returns {boolean} Returns a boolean value
+ */
+
+export const kzillaBotAdminCheck = async (message: Message): Promise<boolean> => {
   if (message.member.roles.cache.find(role => role.id === config.KZILLA_BOT_ADMIN_ID)) return true;
   message.reply(ERROR_MESSAGES.USER_NOT_ADMIN);
   return false;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -54,6 +54,7 @@ export const COMMANDS = {
   KZADMIN_GUILD_COUNT: 'guildcount',
 };
 export const ERROR_MESSAGES = {
+  USER_NOT_ADMIN: 'You do not have the permission to use this command, Mr Bond.',
   UNKNOWN_ERROR: [
     `An error occured with me. I'd tell you but then I'd have to kill you.`,
     `Uh Oh, someone forgot to pay the server bills and now I can't function properly.`,
@@ -82,7 +83,7 @@ export const ERROR_MESSAGES = {
 };
 
 export const MESSAGES = {
-  GUILD_COUNT_MESSAGE: 'Howdy cowboy🤠. Here is the list of the guild I am in:',
+  GUILD_COUNT_MESSAGE: 'Howdy cowboy 🤠! Here is the list of the guilds that I in:',
   PLAYLIST_ADDED: 'Your playlist has been added to the queue! 🎶',
   HELP_TITLE: `Hi! I am ${config.DISCORD_BOT_NAME}, your favourite Music bot! 🤖`,
   HELP_DESCRIPTION:

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -51,6 +51,7 @@ export const COMMANDS = {
   SKIP_TO: 'skipto',
   NEXT: 'next',
   STOP: 'stop',
+  KZADMIN_GUILD_COUNT: 'guildcount',
 };
 export const ERROR_MESSAGES = {
   UNKNOWN_ERROR: [
@@ -81,6 +82,7 @@ export const ERROR_MESSAGES = {
 };
 
 export const MESSAGES = {
+  GUILD_COUNT_MESSAGE: 'Howdy cowboy🤠. Here is the list of the guild I am in:',
   PLAYLIST_ADDED: 'Your playlist has been added to the queue! 🎶',
   HELP_TITLE: `Hi! I am ${config.DISCORD_BOT_NAME}, your favourite Music bot! 🤖`,
   HELP_DESCRIPTION:


### PR DESCRIPTION
# Description

Adds a command (ADMIN only) to fetch the number and names of Guilds the bot is in.

Fixes #22 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested on SRMKZILLA's test server

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
